### PR TITLE
Change pull origin label

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -572,7 +572,10 @@ export class NoChanges extends React.Component<
       aheadBehind.behind === 1 ? 'commit' : 'commits'
     } from the ${remote.name} remote`
 
-    const buttonText = `Pull ${remote.name}`
+    const buttonText =
+      remote.name === 'origin'
+        ? 'Steal changes'
+        : `Steal changes from ${remote.name}`
 
     return (
       <MenuBackedSuggestedAction

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -623,9 +623,11 @@ export class PushPullButton extends React.Component<
     forcePushBranchState: ForcePushBranchState,
     onClick: () => void
   ) {
-    const title = pullWithRebase
-      ? `Pull ${remoteName} with rebase`
-      : `Pull ${remoteName}`
+    const baseTitle =
+      remoteName === 'origin'
+        ? 'Steal changes'
+        : `Steal changes from ${remoteName}`
+    const title = pullWithRebase ? `${baseTitle} with rebase` : baseTitle
 
     const dropdownItemTypes = [DropdownItemType.Fetch]
 

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -280,7 +280,7 @@
   
 ### Next Steps
  - [ ] Up to four suggested steps are shown at any given time, contingent on the state of the repository and/or branch
-   - [ ] First step is not always shown, and it can be `View Stash`, `Pull Origin`, `Pull Origin`, `Create Pull Request`, `Publish Repository`
+  - [ ] First step is not always shown, and it can be `View Stash`, `Steal changes`, `Steal changes from <remote>`, `Create Pull Request`, `Publish Repository`
    - [ ] Other steps are `Open in [editor]` with Preferences/Options link, `Show in [Finder/Explorer]` and `View in GitHub`
 
 ### Repositories list


### PR DESCRIPTION
## Summary
- rename the Pull action text
- show **Steal changes** if remote is `origin`
- show **Steal changes from <remote>** otherwise
- document updated label options

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68890a260498832d89d08a11f0d4b2a2